### PR TITLE
use snyk instead of docker scan

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,5 +10,5 @@ jobs:
         with:
           path: ./testdata
           tag: testdata:${{ github.sha }}
-          docker-scan-enable: true
-          docker-scan-snyk-token: ${{ secrets.SNYK_TOKEN }}
+          snyk-enable: true
+          snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Build and scan Dockerfile and container image by following tools.
 - [hadolint](https://github.com/hadolint/hadolint)
 - [dockle](https://github.com/goodwithtech/dockle)
 - [trivy](https://github.com/aquasecurity/trivy)
-- [docker scan](https://github.com/docker/scan-cli-plugin) (option)
-    - This use [Snyk](https://snyk.io/) internally.
+- [Snyk](https://snyk.io/) (option)
 
 ## Notes
 
@@ -94,20 +93,23 @@ See [action.yaml](./action.yaml) .
     # Ignore unfixed vulnerabilities (default "false")
     trivy-ignore-unfixed: "false"
 
-    # Enable scanning image by docker scan (default "false")
-    # If enabled, "docker-scan-snyk-token" must be also set. 
-    docker-scan-enable: "false"
+    # Enable scanning image by snyk (default "false")
+    # If enabled, "snyk-token" must be also set.
+    syn-enable: "false"
 
-    # Docker scan version (see action.yaml to know default version)
-    docker-scan-version: "0.0.1"
-
-    # Fail step if image has vulnerabilities with a severity above this level (default "low")
-    # Acceptable value is one of (low|medium|high)
-    docker-scan-severity: low
+    # Snyk CLI version (default "1.848.0")
+    snyk-version: "1.848.0"
 
     # Snyk API Token (default "")
-    # This is necessary if "docker-scan-enable" is "true".
-    docker-scan-snyk-token: ""
+    # This is necessary if "snyk-enable" is "true".
+    snyk-token: ""
+
+    # Fail step if image has vulnerabilities with a severity above this level (default "low")
+    # Acceptable value is one of (low|medium|high|critical)
+    snyk-severity: low
+
+    # Exclude base image vulnerabilities (default "false")
+    snyk-exclude-base-image-vulns: "false"
 ```
 
 ## FAQ

--- a/action.yaml
+++ b/action.yaml
@@ -59,22 +59,26 @@ inputs:
     description: Ignore unfixed vulnerabilities (default "false")
     required: false
     default: "false"
-  docker-scan-enable:
-    description: Enable scanning image by docker scan. If enabled, "docker-scan-snyk-token" must be also set. (default "false")
+  snyk-enable:
+    description: Enable scanning image by snyk. If enabled, "snyk-token" must be also set. (default "false")
     required: false
     default: "false"
-  docker-scan-version:
-    description: Docker scan version (default "0.8.0")
+  snyk-version:
+    description: Snyk CLI version (default "1.848.0")
     required: false
-    default: "0.8.0"
-  docker-scan-severity:
-    description: Fail step if image has vulnerabilities with a severity above this level. Acceptable value is one of (low|medium|high). (default "low")
-    required: false
-    default: low
-  docker-scan-snyk-token:
-    description: Snyk API Token. This is necessary if "docker-scan-enable" is "true". (default "")
+    default: "1.848.0"
+  snyk-token:
+    description: Snyk API Token. This is necessary if "snyk-enable" is "true". (default "")
     required: false
     default: ""
+  snyk-severity:
+    description: Fail step if image has vulnerabilities with a severity above this level. Acceptable value is one of (low|medium|high|critical). (default "low")
+    required: false
+    default: low
+  snyk-exclude-base-image-vulns:
+    description: Exclude base image vulnerabilities (default "false")
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -129,23 +133,33 @@ runs:
       echo "::endgroup::"
     if: ${{ inputs.trivy-enable == 'true' }}
     shell: bash
-  - name: Scan image by docker scan
+  - name: Scan image by snyk
     run: |
-      echo "::group::Scan image by docker scan"
+      echo "::group::Scan image by snyk"
 
-      # Install docker scan
-      mkdir -p ${HOME}/.docker/cli-plugins
-      curl -sL https://github.com/docker/scan-cli-plugin/releases/download/v${{ inputs.docker-scan-version }}/docker-scan_linux_amd64 -o ${HOME}/.docker/cli-plugins/docker-scan
-      chmod +x ${HOME}/.docker/cli-plugins/docker-scan
+      # Install snyk
+      curl -sL https://github.com/snyk/snyk/releases/download/v${{ inputs.snyk-version }}/snyk-linux -o /tmp/snyk
+      chmod +x /tmp/snyk
+      sudo mv /tmp/snyk /usr/local/bin/
 
-      # Scan image by docker scan
-      if [ "${{ inputs.docker-scan-snyk-token }}" == "" ]; then
-        echo "'docker-scan-snyk-token' is necessary if 'docker-scan-enable' is 'true'"
+      # Make sure snyk token is passed
+      if [ "${{ inputs.snyk-token }}" == "" ]; then
+        echo "'snyk-token' is necessary if 'snyk-enable' is 'true'"
         exit 1
       fi
-      docker scan --accept-license --login --token "${{ inputs.docker-scan-snyk-token }}"
-      docker scan --accept-license --file "${{ inputs.path }}/${{ inputs.dockerfile }}" --severity "${{ inputs.docker-scan-severity }}" "${{ inputs.tag }}"
+
+      # Construct flags
+      FLAGS=""
+      if [ "${{ inputs.snyk-exclude-base-image-vulns }}" == "true" ]; then
+        FLAGS="--exclude-base-image-vulns"
+      fi
+
+      # Authenticate
+      snyk auth "${{ inputs.snyk-token }}"
+
+      # Scan image by snyk
+      snyk container test --file="${{ inputs.path }}/${{ inputs.dockerfile }}" --severity-threshold="${{ inputs.snyk-severity }}" ${FLAGS} "${{ inputs.tag }}"
 
       echo "::endgroup::"
-    if: ${{ inputs.docker-scan-enable == 'true' }}
+    if: ${{ inputs.snyk-enable == 'true' }}
     shell: bash


### PR DESCRIPTION
We scan container by [snyk](https://snyk.io/) directly instead of [docker scan](https://github.com/docker/scan-cli-plugin) because [docker scan](https://github.com/docker/scan-cli-plugin) use [snyk](https://snyk.io/) internally. 
