### PR TITLE
test: bump image for test to static-debian11

### DIFF
--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -1,2 +1,2 @@
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static-debian10:latest
+FROM gcr.io/distroless/static-debian11:latest


### PR DESCRIPTION
## What's changed?
Bump test image to `gcr.io/distroless/static-debian11:latest`.

## Why?
Trivy detect some vulnerabilities about `gcr.io/distroless/static-debian10:latest` and CI fail.

```
$ trivy image gcr.io/distroless/static-debian10:latest
2023-01-15T23:34:14.508+0900    INFO    Vulnerability scanning is enabled
2023-01-15T23:34:14.508+0900    INFO    Secret scanning is enabled
2023-01-15T23:34:14.508+0900    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-01-15T23:34:14.508+0900    INFO    Please see also https://aquasecurity.github.io/trivy/v0.36/docs/secret/scanning/#recommendation for faster secret detection
2023-01-15T23:34:15.957+0900    INFO    Detected OS: debian
2023-01-15T23:34:15.957+0900    INFO    Detecting Debian vulnerabilities...
2023-01-15T23:34:15.958+0900    INFO    Number of language-specific files: 0

gcr.io/distroless/static-debian10:latest (debian 10.12)

Total: 2 (UNKNOWN: 2, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────┬───────────────┬──────────┬───────────────────┬─────────────────┬────────────────────────────────┐
│ Library │ Vulnerability │ Severity │ Installed Version │  Fixed Version  │             Title              │
├─────────┼───────────────┼──────────┼───────────────────┼─────────────────┼────────────────────────────────┤
│ tzdata  │ DLA-3134-1    │ UNKNOWN  │ 2021a-0+deb10u6   │ 2021a-0+deb10u7 │ tzdata - new timezone database │
│         ├───────────────┤          │                   ├─────────────────┤                                │
│         │ DLA-3161-1    │          │                   │ 2021a-0+deb10u8 │                                │
└─────────┴───────────────┴──────────┴───────────────────┴─────────────────┴────────────────────────────────┘
```

## References
None