### PR TITLE
ci: add renovate workflow to bump tools

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,16 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run renovate
+        uses: renovatebot/github-action@v32.0.1
+        with:
+          token: ${{ secrets.MY_GITHUB_TOKEN }}
+          configurationFile: renovate.json

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See [action.yaml](./action.yaml) .
     # Enable scanning Dockerfile by hadolint (default "true")
     hadolint-enable: "true"
 
-    # Hadolint version (default "2.8.0")
+    # Hadolint version.
     hadolint-version: "2.8.0"
 
     # Fail step if rules with a severity above this level are violated (default "info")
@@ -67,7 +67,7 @@ See [action.yaml](./action.yaml) .
     # Enable scanning image by dockle (default "true")
     dockle-enable: "true"
 
-    # Dockle version (default "0.4.3")
+    # Dockle version.
     docke-version: "0.4.3"
 
     # Fail step if checkpoints with a severity above this level are violated (default "WARN")
@@ -77,7 +77,7 @@ See [action.yaml](./action.yaml) .
     # Enable scanning image by trivy (default "true")
     trivy-enable: "true"
 
-    # Trivy version (default "0.23.0")
+    # Trivy version.
     trivy-version: "0.23.0"
 
     # Fail step if image has vulnerabilities with a severity same as this level
@@ -97,7 +97,7 @@ See [action.yaml](./action.yaml) .
     # If enabled, "snyk-token" must be also set.
     syn-enable: "false"
 
-    # Snyk CLI version (default "1.848.0")
+    # Snyk CLI version.
     snyk-version: "1.848.0"
 
     # Snyk API Token (default "")

--- a/action.yaml
+++ b/action.yaml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: "true"
   hadolint-version:
-    description: Hadolint version (default "2.8.0")
+    description: Hadolint version.
     required: false
-    default: "2.8.0"
+    default: "2.8.0" # renovate:hadolint/hadolint
   hadolint-severity:
     description: Fail step if rules with a severity above this level are violated. Acceptable value is one of (error|warning|info|style|ignore|none). (default "info")
     required: false
@@ -32,9 +32,9 @@ inputs:
     required: false
     default: "true"
   dockle-version:
-    description: Dockle version (default "0.4.3")
+    description: Dockle version.
     required: false
-    default: "0.4.3"
+    default: "0.4.3" # renovate:goodwithtech/dockle
   dockle-severity:
     description: Fail step if checkpoints with a severity above this level are violated. Acceptable value is one of (INFO|WARN|FATAL). (default "WARN")
     required: false
@@ -44,9 +44,9 @@ inputs:
     required: false
     default: "true"
   trivy-version:
-    description: Trivy version (default "0.23.0")
+    description: Trivy version.
     required: false
-    default: "0.23.0"
+    default: "0.23.0" # renovate:aquasecurity/trivy
   trivy-severity:
     description: Fail step if image has vulnerabilities with a severity same as this level. Acceptable value is comma-separated list of (UNKNOWN|LOW|MEDIUM|HIGH|CRITICAL). (default "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL")
     required: false
@@ -64,9 +64,9 @@ inputs:
     required: false
     default: "false"
   snyk-version:
-    description: Snyk CLI version (default "1.848.0")
+    description: Snyk CLI version.
     required: false
-    default: "1.848.0"
+    default: "1.848.0" # renovate:snyk/snyk
   snyk-token:
     description: Snyk API Token. This is necessary if "snyk-enable" is "true". (default "")
     required: false

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+    "repositories": [
+        "ISID/build-and-scan-image"
+    ],
+    "extends": [
+        "config:base",
+        ":prHourlyLimitNone",
+        ":prConcurrentLimitNone",
+        ":disableDependencyDashboard"
+    ],
+    "enabledManagers": [
+        "regex"
+    ],
+    "labels": [
+        "renovate"
+    ],
+    "assignees": [
+        "@ShibataTakao"
+    ],
+    "regexManagers": [
+        {
+            "fileMatch": [
+                "^action.yaml$"
+            ],
+            "matchStrings": [
+                "\"(?<currentValue>[\\d\\.]+)\"\\s*#\\s*renovate:(?<depName>.+)"
+            ],
+            "datasourceTemplate": "github-releases",
+            "versioningTemplate": "semver",
+            "extractVersionTemplate": "^v(?<version>.*)$"
+        }
+    ]
+}


### PR DESCRIPTION
## What's changed?
Add workflow to create PR to update tools' version using renovate.

## Why?
To keep tools' version latest.

## References
None.